### PR TITLE
Lets you configure the default sleep interval from 125ms to something else

### DIFF
--- a/lib/redis-lock.rb
+++ b/lib/redis-lock.rb
@@ -23,7 +23,7 @@ class Redis
     # @param options[:owner] may be set, but defaults to HOSTNAME:PID
     # @param options[:sleep] optional, number of milliseconds to sleep when lock is held, defaults to 125
     def initialize( redis, key, options = {} )
-      check_keys( options, :owner, :life )
+      check_keys( options, :owner, :life, :sleep )
       @redis  = redis
       @key    = key
       @okey   = "lock:owner:#{key}"


### PR DESCRIPTION
@mlanett, this lets you specify what the sleep interval should be. In our app, 125ms is too long since the code in our critical region processes very quickly. We're seeing noticeable slowdowns in our app, so I want to lower it to something like 25ms in our app.
