### PR TITLE
Pass the lock to the supplied block

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This gem adds lock() and unlock() to Redis instances.
 lock() takes a block and is safer than using lock() and unlock() separately.
 lock() takes a key and lifetime and optionally a timeout (otherwise defaulting to 10 second).
 
-redis.lock("test") { do_something }
+redis.lock("test") { |lock| do_something }
 
 ## Problems
 

--- a/lib/redis-lock.rb
+++ b/lib/redis-lock.rb
@@ -37,7 +37,7 @@ class Redis
       do_lock_with_timeout(timeout) or raise LockNotAcquired.new(key)
       if block then
         begin
-          result = block.call
+          result = block.call(self)
         ensure
           release_lock
         end

--- a/spec/redis_lock_spec.rb
+++ b/spec/redis_lock_spec.rb
@@ -26,6 +26,12 @@ describe Redis::Lock, redis: true do
     end.should eql(1)
   end
 
+  it "passes the lock into a supplied block" do
+    hers.lock do |lock|
+      lock.should be_an_instance_of(Redis::Lock)
+    end
+  end
+
   it "can prevent other use of a lock" do
     hers.lock do
       expect { his.lock; his.unlock }.to raise_exception


### PR DESCRIPTION
This enables a block to extend the life of the lock with code such as this:

``` ruby
  redis.lock("test") do |lock|
    array.each do |entry|
      do_something(entry)
      lock.extend_life(60)
    end
  end
```
