### PR TITLE
Fix for ERR unknown command 'Lock'

### DIFF
--- a/lib/redis-lock.rb
+++ b/lib/redis-lock.rb
@@ -228,11 +228,11 @@ class Redis
   # @param options[:acquire] defaults to 10 seconds and can be used to determine how long to wait for a lock.
   def lock( key, options = {}, &block )
     acquire = options.delete(:acquire) || 10
-    Lock.new( self, key, options ).lock( acquire, &block )
+    Redis::Lock.new( self, key, options ).lock( acquire, &block )
   end
 
   def unlock( key )
-    Lock.new( self, key ).unlock
+    Redis::Lock.new( self, key ).unlock
   end
 
 end # Redis


### PR DESCRIPTION
Was getting the above error in rails on the unlock line 235.  Not sure why.  Maybe name conflict or something wasn't getting included properly.
