### PR TITLE
Redis.lock helper return lock when no block is given

### DIFF
--- a/lib/redis-lock.rb
+++ b/lib/redis-lock.rb
@@ -228,7 +228,10 @@ class Redis
   # @param options[:acquire] defaults to 10 seconds and can be used to determine how long to wait for a lock.
   def lock( key, options = {}, &block )
     acquire = options.delete(:acquire) || 10
-    Redis::Lock.new( self, key, options ).lock( acquire, &block )
+
+    lock = Redis::Lock.new self, key, options
+
+    block_given? ? lock.lock(acquire, &block) : lock
   end
 
   def unlock( key )

--- a/spec/redis_lock_spec.rb
+++ b/spec/redis_lock_spec.rb
@@ -136,10 +136,17 @@ describe Redis::Lock, redis: true do
     # We leave [ present, present ] to be unspecified.
   end
 
-  example "How to get a lock using the helper." do
+  example "How to get a lock using the helper when passing a block" do
     redis.lock "mykey", life: 10, acquire: 1 do |lock|
       lock.extend_life 10
-    end
+      :return_value_of_block
+    end.should eql(:return_value_of_block)
+  end
+
+  example "How to get a lock using the helper when not passing a block" do
+    lock = redis.lock "mykey", life: 10, acquire: 1
+    lock.should be_an_instance_of(Redis::Lock)
+    lock.unlock
   end
 
 end


### PR DESCRIPTION
Hey there @mlanett, thank you for this wonderful fork.

We were surprised that Redis.lock returned a nil when used without a block.

This patch changes that, and improves the helper test to make sure everything works as expected in both block given and no block given contexts.